### PR TITLE
Initial Event Sourcing refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+.idea/
+target/

--- a/src/main/java/io/pillopl/consistency/VirtualCreditCard.java
+++ b/src/main/java/io/pillopl/consistency/VirtualCreditCard.java
@@ -16,9 +16,9 @@ class VirtualCreditCard {
     private final List<Event> pendingEvents = new ArrayList<>();
 
     static VirtualCreditCard withLimit(Money limit) {
-        VirtualCreditCard card = new VirtualCreditCard(CardId.random());
-        card.assignLimit(limit);
-        return card;
+        var cartId = CardId.random();
+        List<Event> events = List.of(new LimitAssigned(UUID.randomUUID(), cartId, Instant.now(), limit));
+        return recreate(CardId.random(), events);
     }
 
     static VirtualCreditCard recreate(CardId cardId, List<Event> stream) {

--- a/src/main/java/io/pillopl/consistency/VirtualCreditCard.java
+++ b/src/main/java/io/pillopl/consistency/VirtualCreditCard.java
@@ -106,8 +106,10 @@ class VirtualCreditCard {
         return cardId;
     }
 
-    List<VirtualCreditCardEvent> pendingEvents() {
-        return Collections.unmodifiableList(pendingEvents);
+    List<VirtualCreditCardEvent> dequeuePendingEvents() {
+        var result = pendingEvents.stream().toList();
+        pendingEvents.clear();
+        return result;        
     }
 
     Result success(VirtualCreditCardEvent event) {
@@ -118,10 +120,6 @@ class VirtualCreditCard {
     void enqueue(VirtualCreditCardEvent event) {
         evolve(this, event);
         pendingEvents.add(event);
-    }
-
-    void flush() {
-        pendingEvents.clear();
     }
 }
 

--- a/src/main/java/io/pillopl/consistency/VirtualCreditCardDatabase.java
+++ b/src/main/java/io/pillopl/consistency/VirtualCreditCardDatabase.java
@@ -18,9 +18,7 @@ class VirtualCreditCardDatabase {
 
      VirtualCreditCard find(CardId cardId) {
          List<Event> stream = cards.getOrDefault(cardId, new ArrayList<>());
-         VirtualCreditCard recreate = VirtualCreditCard.recreate(cardId, stream);
-         recreate.flush(); //wink wink ;)
-         return recreate;
+         return VirtualCreditCard.recreate(cardId, stream);
      }
 }
 

--- a/src/main/java/io/pillopl/consistency/VirtualCreditCardDatabase.java
+++ b/src/main/java/io/pillopl/consistency/VirtualCreditCardDatabase.java
@@ -16,13 +16,12 @@ class VirtualCreditCardDatabase {
         var cartId = card.id().id().toString();
         AtomicInteger version = new AtomicInteger(stream.size());
 
-        var newEvents = card.pendingEvents().stream().map(e ->
+        var newEvents = card.dequeuePendingEvents().stream().map(e ->
                 EventEnvelope.from(cartId, e, version.incrementAndGet())
         ).toList();
 
         stream.addAll(newEvents);
         cards.put(card.id(), stream);
-        card.flush();
     }
 
     VirtualCreditCard find(CardId cardId) {

--- a/src/main/java/io/pillopl/consistency/VirtualCreditCardDatabase.java
+++ b/src/main/java/io/pillopl/consistency/VirtualCreditCardDatabase.java
@@ -27,7 +27,7 @@ class VirtualCreditCardDatabase {
 
     VirtualCreditCard find(CardId cardId) {
         List<EventEnvelope> stream = cards.getOrDefault(cardId, new ArrayList<>());
-        return VirtualCreditCard.recreate(cardId, stream.stream()
+        return VirtualCreditCard.recreate(stream.stream()
                 .map(EventEnvelope::data)
                 .filter(event -> event instanceof VirtualCreditCardEvent)
                 .map(event -> (VirtualCreditCardEvent) event)

--- a/src/main/java/io/pillopl/consistency/VirtualCreditCardDatabase.java
+++ b/src/main/java/io/pillopl/consistency/VirtualCreditCardDatabase.java
@@ -1,37 +1,73 @@
 package io.pillopl.consistency;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 class VirtualCreditCardDatabase {
+    private final Map<CardId, List<EventEnvelope>> cards = new ConcurrentHashMap<>();
 
-     private final Map<CardId, List<Event>> cards = new ConcurrentHashMap<>();
+    void save(VirtualCreditCard card) {
+        List<EventEnvelope> stream = cards.getOrDefault(card.id(), new ArrayList<>());
+        var cartId = card.id().id().toString();
+        AtomicInteger version = new AtomicInteger(stream.size());
 
-     void save(VirtualCreditCard card) {
-         List<Event> stream = cards.getOrDefault(card.id(), new ArrayList<>());
-         stream.addAll(card.pendingEvents());
-         cards.put(card.id(), stream);
-         card.flush();
-     }
+        var newEvents = card.pendingEvents().stream().map(e ->
+                EventEnvelope.from(cartId, e, version.incrementAndGet())
+        ).toList();
 
-     VirtualCreditCard find(CardId cardId) {
-         List<Event> stream = cards.getOrDefault(cardId, new ArrayList<>());
-         return VirtualCreditCard.recreate(cardId, stream);
-     }
+        stream.addAll(newEvents);
+        cards.put(card.id(), stream);
+        card.flush();
+    }
+
+    VirtualCreditCard find(CardId cardId) {
+        List<EventEnvelope> stream = cards.getOrDefault(cardId, new ArrayList<>());
+        return VirtualCreditCard.recreate(cardId, stream.stream()
+                .map(EventEnvelope::data)
+                .filter(event -> event instanceof VirtualCreditCardEvent)
+                .map(event -> (VirtualCreditCardEvent) event)
+                .toList()
+        );
+    }
+}
+
+record EventMetadata(
+        String streamId,
+        String eventType,
+        UUID eventId,
+        int version,
+        Instant occurredAt
+) {
+    public static <T> EventMetadata from(Class<T> eventType, String streamId, int version) {
+        return new EventMetadata(streamId, eventType.getTypeName(), UUID.randomUUID(), version, Instant.now());
+    }
+}
+
+record EventEnvelope(
+        Object data,
+        EventMetadata metadata
+) {
+
+    public static <T> EventEnvelope from(String streamId, Object event, int version) {
+        return new EventEnvelope(event, EventMetadata.from(event.getClass(), streamId, version));
+    }
 }
 
 class OwnershipDatabase {
 
-     private final Map<CardId, Ownership> ownerships = new ConcurrentHashMap<>();
+    private final Map<CardId, Ownership> ownerships = new ConcurrentHashMap<>();
 
-     void save(CardId cardId, Ownership ownership) {
-          ownerships.put(cardId, ownership);
-     }
+    void save(CardId cardId, Ownership ownership) {
+        ownerships.put(cardId, ownership);
+    }
 
-     Ownership find(CardId cardId) {
-          return ownerships.getOrDefault(cardId, Ownership.empty());
-     }
+    Ownership find(CardId cardId) {
+        return ownerships.getOrDefault(cardId, Ownership.empty());
+    }
 
 }

--- a/src/test/java/io/pillopl/consistency/WithdrawingTest.java
+++ b/src/test/java/io/pillopl/consistency/WithdrawingTest.java
@@ -198,7 +198,7 @@ class WithdrawingTest {
     }
 
     CardId newCreditCard() {
-        VirtualCreditCard virtualCreditCard = new VirtualCreditCard(CardId.random());
+        VirtualCreditCard virtualCreditCard = VirtualCreditCard.create(CardId.random());
         creditCardDatabase.save(virtualCreditCard);
         return virtualCreditCard.id();
     }


### PR DESCRIPTION
**1. Split event data and metadata.**

Thanks to that, the aggregate doesn't need to know about stuff like event IDs, etc. I moved that information to EventEnvelope, which is used in VirtualCreditCart storage.

Added Virtual Card Event union type, thanks to that we're getting the type safety on apply method. Added missing apply for created event.

**2. Setting up VirtualCreditCard with a limit happens on events** 

Thanks to that, we show that a state can be purely built on events without needing to call business logic

**3. Apply functions are not enqueuing pending events anymore**

New events are now created only by the business logic.
The intention is to make the split between business logic and state more explicit.
Added the unified evolve function that encapsulates state apply logic.

**4. Addedd success helper method** 
Now, it's less likely to forget about enqueuing pending events or calling apply.
The potential downside is that the explicit apply method is not called anymore but implicitly through success=>enqueue=>evolve chain.

**5. Getting and flushing pending events is merged into a single dequeuePendingEvents**

Those methods always happen together now, so let's make that explicit.
