### PR TITLE
Added optimistic concurrency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+indent_size = 4
+tab_width = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.java]
+max_line_length = 80

--- a/src/main/java/io/pillopl/consistency/AddLimitService.java
+++ b/src/main/java/io/pillopl/consistency/AddLimitService.java
@@ -12,9 +12,13 @@ class AddLimitService {
 
     Result addLimit(CardId cardId, Money limit) {
         VirtualCreditCard card = virtualCreditCardDatabase.find(cardId);
+        int expectedVersion = card.version();
+
         Result result = card.assignLimit(limit);
-        virtualCreditCardDatabase.save(card);
-        return result;
+
+        return result == Result.Success ?
+            virtualCreditCardDatabase.save(card, expectedVersion)
+            : result;
     }
 
 }

--- a/src/main/java/io/pillopl/consistency/AddLimitService.java
+++ b/src/main/java/io/pillopl/consistency/AddLimitService.java
@@ -9,12 +9,12 @@ class AddLimitService {
     AddLimitService(VirtualCreditCardDatabase virtualCreditCardDatabase) {
         this.virtualCreditCardDatabase = virtualCreditCardDatabase;
     }
-    
+
     Result addLimit(CardId cardId, Money limit) {
         VirtualCreditCard card = virtualCreditCardDatabase.find(cardId);
         Result result = card.assignLimit(limit);
         virtualCreditCardDatabase.save(card);
         return result;
     }
-    
+
 }

--- a/src/main/java/io/pillopl/consistency/CloseCycleService.java
+++ b/src/main/java/io/pillopl/consistency/CloseCycleService.java
@@ -10,10 +10,12 @@ class CloseCycleService {
 
     Result close(CardId cardId) {
         VirtualCreditCard card = virtualCreditCardDatabase.find(cardId);
+        int expectedVersion = card.version();
+
         Result result = card.closeCycle();
 
         return result == Result.Success ?
-            virtualCreditCardDatabase.save(card)
+            virtualCreditCardDatabase.save(card, expectedVersion)
             : result;
     }
 }

--- a/src/main/java/io/pillopl/consistency/CloseCycleService.java
+++ b/src/main/java/io/pillopl/consistency/CloseCycleService.java
@@ -11,9 +11,10 @@ class CloseCycleService {
     Result close(CardId cardId) {
         VirtualCreditCard card = virtualCreditCardDatabase.find(cardId);
         Result result = card.closeCycle();
-        virtualCreditCardDatabase.save(card);
-        return result;
 
+        return result == Result.Success ?
+            virtualCreditCardDatabase.save(card)
+            : result;
     }
 }
 

--- a/src/main/java/io/pillopl/consistency/Database.java
+++ b/src/main/java/io/pillopl/consistency/Database.java
@@ -1,0 +1,115 @@
+package io.pillopl.consistency;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+interface Versioned {
+    int getVersion();
+
+    void setVersion(int version);
+}
+
+record RecordWithVersion(Object record, int version) {
+    static RecordWithVersion noRecord = new RecordWithVersion(null, 0);
+}
+
+class Database {
+    static <T> DatabaseCollection<T> collection(Class<T> entryClass) {
+        return new DatabaseCollection<>(entryClass);
+    }
+}
+
+
+class DatabaseCollection<T> {
+    private final Class<T> entryClass;
+    private final Map<String, RecordWithVersion> entries = new ConcurrentHashMap<>();
+
+    DatabaseCollection(Class<T> entryClass) {
+        this.entryClass = entryClass;
+    }
+
+    Result save(String id, T record) {
+        return save(id, record, record instanceof Versioned versioned ?
+            versioned.getVersion()
+            : entries.getOrDefault(id, RecordWithVersion.noRecord).version()
+        );
+    }
+
+    Result save(String id, T record, int expectedVersion) {
+        var newExpectedVersion = expectedVersion + 1;
+        var wasUpdated = new AtomicBoolean(false);
+
+        entries.compute(id, (key, currentValue) -> {
+            var currentVersion = currentValue != null ? currentValue.version() : 0;
+
+            if (currentVersion != expectedVersion) {
+                // Version conflict, don't update the value
+                return currentValue;  // Keep the currentValue in the map
+            }
+
+            if (record instanceof Versioned versioned) {
+                versioned.setVersion(newExpectedVersion);
+            }
+            wasUpdated.set(true);
+
+            return new RecordWithVersion(record, newExpectedVersion);
+        });
+
+        return wasUpdated.get() ?
+            Result.Success
+            : Result.Failure;
+    }
+
+    Optional<T> find(String id) {
+        return entries.containsKey(id) ?
+            Optional.of(entryClass.cast(entries.get(id).record()))
+            : Optional.empty();
+    }
+
+    Result findAndUpdate(Class<T> recordClass, String id, Function<T, T> handle, Supplier<T> getDefault) {
+        var entry = entries.getOrDefault(id, RecordWithVersion.noRecord);
+
+        var result = handle.apply(Optional.ofNullable(entry.record())
+            .map(recordClass::cast)
+            .orElse(getDefault.get()));
+
+        return save(id, result, entry.version());
+    }
+}
+
+record EventStream(String id, List<EventEnvelope> events) {
+    static EventStream empty(String id) {
+        return new EventStream(null, new ArrayList<>());
+    }
+
+    EventStream append(List<EventEnvelope> events) {
+        return new EventStream(id, Stream.concat(this.events.stream(), events.stream()).toList());
+    }
+}
+
+record EventMetadata(
+    String streamId,
+    String eventType,
+    UUID eventId,
+    int version,
+    Instant occurredAt
+) {
+    public static <T> EventMetadata from(Class<T> eventType, String streamId, int version) {
+        return new EventMetadata(streamId, eventType.getTypeName(), UUID.randomUUID(), version, Instant.now());
+    }
+}
+
+record EventEnvelope(
+    Object data,
+    EventMetadata metadata
+) {
+
+    public static <T> EventEnvelope from(String streamId, Object event, int version) {
+        return new EventEnvelope(event, EventMetadata.from(event.getClass(), streamId, version));
+    }
+}

--- a/src/main/java/io/pillopl/consistency/EventStore.java
+++ b/src/main/java/io/pillopl/consistency/EventStore.java
@@ -1,0 +1,83 @@
+package io.pillopl.consistency;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+public class EventStore {
+    private final DatabaseCollection<EventStream> streams = Database.collection(EventStream.class);
+
+    <T> List<T> readEvents(Class<T> eventType, String streamId) {
+        return existingEventStreamOrEmpty(streamId)
+            .eventsOfType(eventType);
+    }
+
+    <T> Result appendToStream(String streamId, List<T> events, int expectedVersion) {
+        var version = new AtomicInteger(expectedVersion);
+
+        var stream = existingEventStreamOrEmpty(streamId);
+
+        var newEvents = events.stream().map(e ->
+            EventEnvelope.from(streamId, e, version.incrementAndGet())
+        ).toList();
+
+        return streams.save(streamId, stream.append(newEvents), expectedVersion);
+    }
+
+    private EventStream existingEventStreamOrEmpty(String streamId) {
+        return streams.find(streamId)
+            .orElseGet(() -> EventStream.empty(streamId));
+    }
+}
+
+record EventStream(String id, List<EventEnvelope> events) {
+    static EventStream empty(String id) {
+        return new EventStream(null, new ArrayList<>());
+    }
+
+    EventStream append(List<EventEnvelope> events) {
+        return new EventStream(id, Stream.concat(this.events.stream(), events.stream()).toList());
+    }
+
+    <T> List<T> eventsOfType(Class<T> eventType) {
+        return events().stream()
+            .map(EventEnvelope::data)
+            .filter(eventType::isInstance)
+            .map(event -> (T) event)
+            .toList();
+    }
+}
+
+record EventMetadata(
+    String streamId,
+    String eventType,
+    UUID eventId,
+    int version,
+    Instant occurredAt
+) {
+    public static <T> EventMetadata from(Class<T> eventType, String streamId, int version) {
+        return new EventMetadata(
+            streamId,
+            eventType.getTypeName(),
+            UUID.randomUUID(),
+            version,
+            Instant.now()
+        );
+    }
+}
+
+record EventEnvelope(
+    Object data,
+    EventMetadata metadata
+) {
+
+    public static EventEnvelope from(String streamId, Object event, int version) {
+        return new EventEnvelope(
+            event,
+            EventMetadata.from(event.getClass(), streamId, version)
+        );
+    }
+}

--- a/src/main/java/io/pillopl/consistency/OwnershipService.java
+++ b/src/main/java/io/pillopl/consistency/OwnershipService.java
@@ -10,16 +10,22 @@ class OwnershipService {
 
     Result addAccess(CardId cardId, OwnerId ownerId) {
         Ownership ownership = ownershipDatabase.find(cardId);
+        var expectedVersion = ownership.version();
+
         if (ownership.size() >= 2) {
             return Result.Failure;
         }
         ownership = ownership.addAccess(ownerId);
-        return ownershipDatabase.save(cardId, ownership);
+
+        return ownershipDatabase.save(cardId, ownership, expectedVersion);
     }
 
     Result revokeAccess(CardId cardId, OwnerId ownerId) {
         Ownership ownership = ownershipDatabase.find(cardId);
+        var expectedVersion = ownership.version();
+
         ownership = ownership.revoke(ownerId);
-        return ownershipDatabase.save(cardId, ownership);
+
+        return ownershipDatabase.save(cardId, ownership, expectedVersion);
     }
 }

--- a/src/main/java/io/pillopl/consistency/OwnershipService.java
+++ b/src/main/java/io/pillopl/consistency/OwnershipService.java
@@ -14,14 +14,12 @@ class OwnershipService {
             return Result.Failure;
         }
         ownership = ownership.addAccess(ownerId);
-        ownershipDatabase.save(cardId, ownership);
-        return Result.Success;
+        return ownershipDatabase.save(cardId, ownership);
     }
 
     Result revokeAccess(CardId cardId, OwnerId ownerId) {
         Ownership ownership = ownershipDatabase.find(cardId);
         ownership = ownership.revoke(ownerId);
-        ownershipDatabase.save(cardId, ownership);
-        return Result.Success;
+        return ownershipDatabase.save(cardId, ownership);
     }
 }

--- a/src/main/java/io/pillopl/consistency/RepayService.java
+++ b/src/main/java/io/pillopl/consistency/RepayService.java
@@ -12,9 +12,13 @@ class RepayService {
 
     Result repay(CardId cardId, Money amount) {
         VirtualCreditCard card = virtualCreditCardDatabase.find(cardId);
+        int expectedVersion = card.version();
+
         Result result = card.repay(amount);
-        virtualCreditCardDatabase.save(card);
-        return result;
+
+        return result == Result.Success ?
+            virtualCreditCardDatabase.save(card, expectedVersion)
+            : result;
 
     }
 }

--- a/src/test/java/io/pillopl/consistency/DatabaseTest.java
+++ b/src/test/java/io/pillopl/consistency/DatabaseTest.java
@@ -12,7 +12,6 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-
 class DummyEntity {
     private final String id;
 
@@ -25,7 +24,7 @@ class DummyEntity {
     }
 }
 
-class DummyVersionedEntity implements Versioned {
+class DummyVersionedEntity implements VersionedWithAutoIncrement {
     private final String id;
     private int version;
 
@@ -35,7 +34,7 @@ class DummyVersionedEntity implements Versioned {
     }
 
     @Override
-    public int getVersion() {
+    public int version() {
         return version;
     }
 
@@ -91,7 +90,7 @@ public class DatabaseTest {
 
         // then
         assertEquals(Result.Success, result);
-        assertEquals(1, entity.getVersion());
+        assertEquals(1, entity.version());
     }
 
     @Test
@@ -122,7 +121,7 @@ public class DatabaseTest {
         // then
         var entityFromDb = collection.find(id);
         assertTrue(entityFromDb.isPresent());
-        assertEquals(1, entityFromDb.get().getVersion());
+        assertEquals(1, entityFromDb.get().version());
     }
 
     @Test
@@ -139,7 +138,7 @@ public class DatabaseTest {
 
             // then
             assertEquals(Result.Success, result);
-            assertEquals(++currentVersion, entity.getVersion());
+            assertEquals(++currentVersion, entity.version());
         } while(currentVersion < 5);
     }
 
@@ -174,7 +173,7 @@ public class DatabaseTest {
 
             // then
             assertEquals(Result.Success, result);
-            assertEquals(++currentVersion, entity.getVersion());
+            assertEquals(++currentVersion, entity.version());
         } while(currentVersion < 5);
     }
 
@@ -192,7 +191,7 @@ public class DatabaseTest {
 
         // then
         assertEquals(Result.Success, result);
-        assertEquals(2, entity.getVersion());
+        assertEquals(2, entity.version());
     }
 
     @Test
@@ -226,7 +225,7 @@ public class DatabaseTest {
 
         // then
         assertEquals(Result.Failure, result);
-        assertEquals(1, entity.getVersion());
+        assertEquals(1, entity.version());
     }
 
     @Test
@@ -253,6 +252,6 @@ public class DatabaseTest {
 
         //then
         assertTrue(results.contains(Result.Failure));
-        assertTrue(collection.find(id).orElse(new DummyVersionedEntity(id, 0)).getVersion() < 10);
+        assertTrue(collection.find(id).orElse(new DummyVersionedEntity(id, 0)).version() < 10);
     }
 }

--- a/src/test/java/io/pillopl/consistency/DatabaseTest.java
+++ b/src/test/java/io/pillopl/consistency/DatabaseTest.java
@@ -1,0 +1,258 @@
+package io.pillopl.consistency;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+class DummyEntity {
+    private final String id;
+
+    DummyEntity(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+}
+
+class DummyVersionedEntity implements Versioned {
+    private final String id;
+    private int version;
+
+    DummyVersionedEntity(String id, int version) {
+        this.id = id;
+        this.version = version;
+    }
+
+    @Override
+    public int getVersion() {
+        return version;
+    }
+
+    @Override
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public String getId() {
+        return id;
+    }
+}
+
+public class DatabaseTest {
+    @Test
+    void findForNonExistingRecordReturnsEmptyOptional() {
+        // given
+        var collection = Database.collection(DummyVersionedEntity.class);
+        var id = UUID.randomUUID().toString();
+
+        // when
+        var result = collection.find(id);
+
+        // then
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void findForExistingRecordReturnsEntity() {
+        // given
+        var collection = Database.collection(DummyVersionedEntity.class);
+        var id = UUID.randomUUID().toString();
+        var entity = new DummyVersionedEntity(id, 0);
+        collection.save(id, entity);
+
+        // when
+        var result = collection.find(id);
+
+        // then
+        assertTrue(result.isPresent());
+        assertEquals(id, result.get().getId());
+    }
+
+    @Test
+    void saveBumpsVersionForVersionedEntity() {
+        // given
+        var collection = Database.collection(DummyVersionedEntity.class);
+        var id = UUID.randomUUID().toString();
+        var entity = new DummyVersionedEntity(id, 0);
+
+        // when
+        var result = collection.save(id, entity);
+
+        // then
+        assertEquals(Result.Success, result);
+        assertEquals(1, entity.getVersion());
+    }
+
+    @Test
+    void saveStoresNonVersionedEntity() {
+        // given
+        var collection = Database.collection(DummyEntity.class);
+        var id = UUID.randomUUID().toString();
+        var entity = new DummyEntity(id);
+
+        // when
+        var result = collection.save(id, entity);
+
+        // then
+        assertEquals(Result.Success, result);
+        assertEquals(id, entity.getId());
+    }
+
+    @Test
+    void saveBumpsVersionInDatabaseForVersionedEntity() {
+        // given
+        var collection = Database.collection(DummyVersionedEntity.class);
+        var id = UUID.randomUUID().toString();
+        var entity = new DummyVersionedEntity(id, 0);
+
+        // when
+        collection.save(id, entity);
+
+        // then
+        var entityFromDb = collection.find(id);
+        assertTrue(entityFromDb.isPresent());
+        assertEquals(1, entityFromDb.get().getVersion());
+    }
+
+    @Test
+    void saveVersionedEntityCanBeRunMultipleTimesSequentially() {
+        // given
+        var collection = Database.collection(DummyVersionedEntity.class);
+        var id = UUID.randomUUID().toString();
+        var currentVersion = 0;
+        var entity = new DummyVersionedEntity(id, currentVersion);
+
+        // when
+        do {
+            var result = collection.save(id, entity);
+
+            // then
+            assertEquals(Result.Success, result);
+            assertEquals(++currentVersion, entity.getVersion());
+        } while(currentVersion < 5);
+    }
+
+    @Test
+    void saveEntityCanBeRunMultipleTimesSequentiallyWithBumpedVersion() {
+        // given
+        var collection = Database.collection(DummyEntity.class);
+        var id = UUID.randomUUID().toString();
+        var currentVersion = 0;
+        var entity = new DummyEntity(id);
+
+        // when
+        do {
+            var result = collection.save(id, entity, currentVersion++);
+
+            // then
+            assertEquals(Result.Success, result);
+        } while(currentVersion < 5);
+    }
+
+    @Test
+    void saveVersionedEntityCanBeRunMultipleTimesSequentiallyWithBumpedVersion() {
+        // given
+        var collection = Database.collection(DummyVersionedEntity.class);
+        var id = UUID.randomUUID().toString();
+        var currentVersion = 0;
+        var entity = new DummyVersionedEntity(id, currentVersion);
+
+        // when
+        do {
+            var result = collection.save(id, entity, currentVersion);
+
+            // then
+            assertEquals(Result.Success, result);
+            assertEquals(++currentVersion, entity.getVersion());
+        } while(currentVersion < 5);
+    }
+
+    @Test
+    void saveVersionedEntitySucceedsWhenExplicitExpectedVersionMatches() {
+        // given
+        var collection = Database.collection(DummyVersionedEntity.class);
+        var id = UUID.randomUUID().toString();
+        var entity = new DummyVersionedEntity(id, 0);
+
+        collection.save(id, entity, 0);
+
+        // when
+        var result = collection.save(id, entity, 1);
+
+        // then
+        assertEquals(Result.Success, result);
+        assertEquals(2, entity.getVersion());
+    }
+
+    @Test
+    void saveEntitySucceedsWhenExplicitExpectedVersionMatches() {
+        // given
+        var collection = Database.collection(DummyEntity.class);
+        var id = UUID.randomUUID().toString();
+        var entity = new DummyEntity(id);
+
+        collection.save(id, entity, 0);
+
+        // when
+        var result = collection.save(id, entity, 1);
+
+        // then
+        assertEquals(Result.Success, result);
+    }
+
+    @Test
+    void saveFailsWhenExplicitExpectedVersionMatches() {
+        // given
+        var collection = Database.collection(DummyVersionedEntity.class);
+        var id = UUID.randomUUID().toString();
+        var entity = new DummyVersionedEntity(id, 0);
+        var oldEntity = new DummyVersionedEntity(id, 0);
+
+        collection.save(id, entity);
+
+        // when
+        var result = collection.save(id, oldEntity);
+
+        // then
+        assertEquals(Result.Failure, result);
+        assertEquals(1, entity.getVersion());
+    }
+
+    @Test
+    void cantUpdateConcurrently() throws InterruptedException {
+        //given
+        var collection = Database.collection(DummyVersionedEntity.class);
+        var id = UUID.randomUUID().toString();
+
+        List<Result> results = new ArrayList<>();
+        //when
+        ExecutorService executor = Executors.newFixedThreadPool(5);
+        for (int i = 0; i<10; i++) {
+            executor.execute(()-> {
+                try {
+                    var entity = collection.find(id).orElse(new DummyVersionedEntity(id, 0));
+                    results.add(collection.save(id, entity));
+                } catch (Exception e) {
+                    // ignore
+                }
+            });
+        }
+        executor.shutdown();
+        executor.awaitTermination(10, TimeUnit.SECONDS);
+
+        //then
+        assertTrue(results.contains(Result.Failure));
+        assertTrue(collection.find(id).orElse(new DummyVersionedEntity(id, 0)).getVersion() < 10);
+    }
+}

--- a/src/test/java/io/pillopl/consistency/WithdrawingTest.java
+++ b/src/test/java/io/pillopl/consistency/WithdrawingTest.java
@@ -199,7 +199,7 @@ class WithdrawingTest {
 
     CardId newCreditCard() {
         VirtualCreditCard virtualCreditCard = VirtualCreditCard.create(CardId.random());
-        creditCardDatabase.save(virtualCreditCard);
+        creditCardDatabase.save(virtualCreditCard, 0);
         return virtualCreditCard.id();
     }
 


### PR DESCRIPTION
**1. Added optimistic concurrency handling**
Added explicit expected version usage in the database and event store. Entities can express that they maintain their own versions through `Versioned` interface. 

Made both `Ownership` and `VirtualCreditCard` implement it to showcase that Optimistic Concurrency can be handled for both regular and event-sourced entities.

**2. Unified database usage with a simple in-memory database**

It already supports optimistic concurrency and can be used both for a regular database and an event store.

Added the explicit event store implementation to showcase how event stores are built. Internally it's using the same in-memory database as ownership database. That also shows that the event store is "just" a key/value database, where value is a list of events (a.k.a. Event Stream).